### PR TITLE
Add configurable layer and exclusive zone options  

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ https://github.com/user-attachments/assets/c4e84d3c-c93f-4bfe-b5e9-f7888b3b8b53
 - **Idle Mode** - Automatically morphs into visualizer/display after inactivity
 - **Now Playing Notifications** - Elegant slide-in notifications for track changes
 - **Configurable Layout** - Position on any screen edge (left, right, top, bottom)
+- **Layer & Exclusive Zone Control** - Choose which layer to render on and whether to overlap other surfaces like waybar
 - **Gaming Support** - Control music during gameplay without moving mouse
 - **Minimal Resource Usage** - ~80-95MB RAM, <0.3% CPU, drops to 20-30MB in idle mode
 - **Dynamic Island Inspired Animation** - Smooth morphing transitions between modes
@@ -316,6 +317,17 @@ edge = right
 # Margin from the screen edge (in pixels)
 margin = 10
 
+# Layer to render on (works on any wlr-layer-shell compositor)
+# Options: background, bottom, top, overlay
+# Use "top" to stay below fullscreen windows (same layer as waybar)
+# Use "overlay" to render above everything including fullscreen
+layer = top
+
+# Exclusive zone controls surface overlap behavior
+# 0 = respect other surfaces' reserved space (e.g. waybar)
+# -1 = overlap everything, ignore other surfaces' exclusive zones
+exclusive_zone = 0
+
 [Notifications]
 enabled = true
 now_playing = true
@@ -337,6 +349,8 @@ preference = spotify,vlc,firefox,brave
 ```
 
 **Note:** Position and themes can be changed on-the-fly without editing config!
+
+**Note:** The `layer` and `exclusive_zone` options use the `wlr-layer-shell` protocol and work on **any compatible Wayland compositor** (Hyprland, Sway, river, wayfire, Niri, etc.) — they are not Hyprland-specific.
 
 ## Customization
 

--- a/config.conf
+++ b/config.conf
@@ -8,6 +8,13 @@ edge = top
 # Margin from the screen edge (in pixels)
 margin = 10
 
+# Layer to render on
+# Options: background, bottom, top, overlay
+layer = top
+
+# Exclusive zone: 0 = respect other surfaces, -1 = overlap everything
+exclusive_zone = 0
+
 [Notifications]
 enabled = true
 now_playing = true

--- a/layout.c
+++ b/layout.c
@@ -29,6 +29,13 @@ gchar *default_config =
     "# Margin from the screen edge (in pixels)\n"
     "margin = 10\n"
     "\n"
+    "# Layer to render on\n"
+    "# Options: background, bottom, top, overlay\n"
+    "layer = top\n"
+    "\n"
+    "# Exclusive zone: 0 = respect other surfaces, -1 = overlap everything\n"
+    "exclusive_zone = 0\n"
+    "\n"
     "[MusicPlayer]\n"
     "# Comma-separated list of preferred music players (first = highest priority)\n"
     "# HyprWave will search for these in order and latch onto the first one found\n"
@@ -75,6 +82,8 @@ gchar *default_config =
 // Set defaults
 config->edge = EDGE_RIGHT;
 config->margin = 10;
+config->layer = GTK_LAYER_SHELL_LAYER_OVERLAY;
+config->exclusive_zone = 0;
 config->toggle_visibility_bind = g_strdup("Super+Shift+M");
 config->toggle_expand_bind = g_strdup("Super+M");
 config->notifications_enabled = TRUE;
@@ -106,7 +115,28 @@ config->player_preference_count = 0;            // NEW
         
         config->margin = g_key_file_get_integer(keyfile, "General", "margin", NULL);
         if (config->margin == 0) config->margin = 10;
-        
+
+        gchar *layer_str = g_key_file_get_string(keyfile, "General", "layer", NULL);
+        if (layer_str) {
+            if (g_strcmp0(layer_str, "background") == 0) {
+                config->layer = GTK_LAYER_SHELL_LAYER_BACKGROUND;
+            } else if (g_strcmp0(layer_str, "bottom") == 0) {
+                config->layer = GTK_LAYER_SHELL_LAYER_BOTTOM;
+            } else if (g_strcmp0(layer_str, "top") == 0) {
+                config->layer = GTK_LAYER_SHELL_LAYER_TOP;
+            } else {
+                config->layer = GTK_LAYER_SHELL_LAYER_OVERLAY;
+            }
+            g_free(layer_str);
+        }
+
+        GError *ez_err = NULL;
+        gint ez_val = g_key_file_get_integer(keyfile, "General", "exclusive_zone", &ez_err);
+        if (!ez_err) {
+            config->exclusive_zone = ez_val;
+        }
+        g_clear_error(&ez_err);
+
         // Load Keybinds section (optional)
         gchar *vis_bind = g_key_file_get_string(keyfile, "Keybinds", "toggle_visibility", NULL);
         if (vis_bind) {

--- a/layout.h
+++ b/layout.h
@@ -14,6 +14,8 @@ typedef enum {
 typedef struct {
     ScreenEdge edge;
     int margin;
+    GtkLayerShellLayer layer;
+    int exclusive_zone;
     gboolean is_vertical;
     gchar *toggle_visibility_bind;
     gchar *toggle_expand_bind;

--- a/main.c
+++ b/main.c
@@ -1598,11 +1598,11 @@ static void activate(GtkApplication *app, gpointer user_data) {
     
     // LAYER SHELL SETUP
     gtk_layer_init_for_window(GTK_WINDOW(window));
-    gtk_layer_set_layer(GTK_WINDOW(window), GTK_LAYER_SHELL_LAYER_OVERLAY);
+    gtk_layer_set_layer(GTK_WINDOW(window), state->layout->layer);
     gtk_layer_set_namespace(GTK_WINDOW(window), "hyprwave");
     layout_setup_window_anchors(GTK_WINDOW(window), state->layout);
     gtk_layer_set_keyboard_mode(GTK_WINDOW(window), GTK_LAYER_SHELL_KEYBOARD_MODE_NONE);
-    gtk_layer_set_exclusive_zone(GTK_WINDOW(window), 0);
+    gtk_layer_set_exclusive_zone(GTK_WINDOW(window), state->layout->exclusive_zone);
     gtk_widget_set_name(window, "hyprwave-window");
     gtk_widget_add_css_class(window, "hyprwave-window");
     


### PR DESCRIPTION
## Summary                                                               
   
  - Add layer config option to select which layer-shell layer hyprwave  
  renders on (background, bottom, top, overlay). Defaults to overlay.
  - Add exclusive_zone config option to control surface overlap behavior
   (0 = respect other surfaces, -1 = overlap everything). Defaults to 0. This can be used for cool setups with status bar ( see video below)
  - Both options are under [General] in config.conf.


https://github.com/user-attachments/assets/bfa8b3ff-1a09-4d06-b83a-3e43ee5e8234


